### PR TITLE
Sync RPG-Kit translation READMEs (zh-CN / ja-JP / ko-KR / hi-IN) to English

### DIFF
--- a/RPG-Kit/README.hi-IN.md
+++ b/RPG-Kit/README.hi-IN.md
@@ -8,73 +8,116 @@
   <a href="README.hi-IN.md">हिन्दी</a>
 </p>
 
-## AI coding agents को पूरे repository को समझने दें
+## कोडिंग एजेंट्स को संपादन से पहले प्लानिंग करने दें
 
-AI coding agents शक्तिशाली होते हैं, लेकिन वे अक्सर file-by-file काम करते हैं। जैसे-जैसे project बढ़ता है, वे requirements, architecture, dependencies, और पिछले design decisions का track खो सकते हैं।
+कोडिंग एजेंट्स लोकल संपादन में मजबूत होते हैं, लेकिन एक स्थिर प्लानिंग संरचना के बिना रिपॉज़िटरी-स्तर के कार्य अक्सर विफल हो जाते हैं। आवश्यकताएँ बहक जाती हैं, आर्किटेक्चर के निर्णय खो जाते हैं, मल्टी-फ़ाइल जनरेशन असंगत हो जाती है, और अपडेट छिपी हुई dependencies को मिस कर सकते हैं।
 
-RPG-Kit इस समस्या को **Repository Planning Graph (RPG)** maintain करके हल करने में मदद करता है: एक structured map जो requirements, features, files, components, और dependencies को जोड़ता है।
+RPG-Kit, Claude Code और GitHub Copilot को रिपॉज़िटरी-स्तर कोडिंग के लिए एक **persistent RPG workspace** देता है। यह वर्कस्पेस एक **Repository Planning Graph (RPG)** के चारों ओर बना है, जो आवश्यकताओं, features, आर्किटेक्चर, फ़ाइलों, कोड entities और dependencies को जोड़ता है।
 
-जब आप चाहते हैं कि AI agents isolated prompts के बजाय repository-level context के साथ काम करें, तब RPG-Kit का उपयोग करें।
+RPG-Kit के साथ, एजेंट्स ग्राफ-संचालित वर्कफ़्लो के माध्यम से काम करते हैं:
 
-### RPG-Kit क्यों?
+- **Build (निर्माण)**: आवश्यकताओं को RPG प्लान में बदलें, फिर एक मल्टी-फ़ाइल रिपॉज़िटरी बनाएँ।
+- **Understand (समझें)**: किसी मौजूदा रिपॉज़िटरी को RPG में मैप करें, फिर खोजें, अन्वेषण करें और समझाएँ।
+- **Update (अपडेट करें)**: प्रभावित RPG नोड्स को पहचानें, संपादन प्लान बनाएँ, और कोड व ग्राफ को एक साथ अपडेट करें।
 
-| AI coding agents की common problem | RPG-Kit कैसे मदद करता है |
-|---|---|
-| Agent कुछ prompts के बाद requirements भूल जाता है | Requirements RPG में encode की जाती हैं |
-| Agent related files को समझे बिना एक file edit करता है | Files, components, और dependencies graph में connected होते हैं |
-| Generated code original plan से drift हो जाता है | Planning artifacts और code aligned रखे जाते हैं |
-| Existing repositories को agents के लिए समझना कठिन होता है | Codebase को RPG में encode किया जा सकता है |
-| Targeted edits hidden dependencies तोड़ सकते हैं | Edits graph-aware context के साथ किए जाते हैं |
+### अपना वर्कफ़्लो चुनें
 
-### अपना workflow चुनें
-
-| Goal | Workflow | Start here |
+| लक्ष्य | वर्कफ़्लो | यहाँ से शुरू करें |
 |---|---|---|
-| Requirements से नया project create करें | Forward workflow | [`Quick Start: नया Repository`](#quick-start-new-repository) |
-| Existing codebase को समझें या update करें | Reverse workflow | [`Quick Start: मौजूदा Repository`](#quick-start-existing-repository) |
-| Precise repository-aware edit करें | Surgical edit workflow | [`Quick Start: मौजूदा Repository`](#quick-start-existing-repository) |
+| आवश्यकताओं से एक नई रिपॉज़िटरी बनाना | Build वर्कफ़्लो (requirements → RPG → code) | [`Quick Start: नई रिपॉज़िटरी`](#quick-start-नई-रिपॉज़िटरी) |
+| किसी मौजूदा रिपॉज़िटरी को समझना | Understand वर्कफ़्लो (repository → RPG → search/explore) | [`Quick Start: मौजूदा रिपॉज़िटरी`](#quick-start-मौजूदा-रिपॉज़िटरी) |
+| किसी मौजूदा रिपॉज़िटरी को अपडेट करना | Update वर्कफ़्लो (change request → affected RPG nodes → edit plan → code/RPG update) | [`Quick Start: मौजूदा रिपॉज़िटरी`](#quick-start-मौजूदा-रिपॉज़िटरी) |
 
-नीचे इस repository के लिए generated graph visualization का एक हिस्सा है। `/rpgkit.encode` चलाएँ और full interactive graph explore करने के लिए `rpg.html` खोलें।
+### विस्तृत पाइपलाइन
+
+नए उपयोगकर्ता इस सेक्शन को छोड़कर सीधे नीचे दिए गए Quick Start से शुरू कर सकते हैं।
+
+<details>
+<summary>कमांड-स्तर का पूर्ण वर्कफ़्लो आरेख</summary>
+
+```text
+Forward Direction: Requirements → RPG → Code
+
+ Phase 1: Feature Specification       Phase 2: RPG Construction & Planning                             Phase 3
+┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
+│ feature  │ │ feature  │ │ feature  │ │  build   │ │  build   │ │ design   │ │ design   │ │  plan    │ │          │
+│  _spec   ├─▶  _build  ├─▶_refactor ├─▶ skeleton ├─▶  data    ├─▶  base    ├─▶interfaces├─▶  tasks  ├─▶ code_gen │
+│          │ │          │ │          │ │          │ │  flow    │ │ classes  │ │          │ │          │ │   (TDD)  │
+└──────────┘ └──────────┘ └────┬─────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘ └────┬─────┘
+ feature_     feature_        │        skeleton     data_flow    base_        interfaces   tasks        source
+ spec/        build           │        .json        .json        classes      .json        .json        code
+ feature_     .json           │        skeleton_    data_flow    .json
+ spec.json                    │        summary.txt  _viz.html
+                              │
+                       ┌──────▼──────┐
+                       │ feature_edit│ optional pre-planning edits to feature_tree.json
+                       └─────────────┘
+                                        ╰───── rpg.json (created → progressively enriched) ─────╯
+                                                                            │
+                                                                            ▼
+                                                                     ┌──────────┐
+Surgical edit workflow: Requirements -> RPG update -> Code Update    │ rpg_edit │ optional synchronized RPG + code + dep_graph edits
+                                                                     └──▲────▲──┘
+                                                                        │    │
+Reverse Direction: Code → RPG                                           │    │
+                                                                        │    │
+┌──────────────────┐         ┌──────────┐       ┌──────────┐            │    │
+│ Existing Codebase│────────▶│  encode  │──────▶│update_rpg│────────────┘    │
+│                  │         │  (full)  │       │ (manual  │                 │
+└──────────────────┘         └────┬─────┘       │ fallback)│                 │
+                              rpg.json          └──────────┘                 │
+                              dep_graph.json     rpg.json / dep_graph.json   │
+                                  │                                          │
+                                  └──────────────────────────────────────────┘
+                                                  ▲
+                                                  │ post-commit hook normally runs incremental updates
+
+MCP Server: search_rpg / explore_rpg / get_node_detail / list_rpg_tree
+```
+
+</details>
+
+### RPG-Kit वास्तविक उपयोग में
+
+नीचे दी गई छवि इस रिपॉज़िटरी के लिए जनरेट किए गए ग्राफ़ विज़ुअलाइज़ेशन का एक भाग है। `/rpgkit.encode` चलाएँ और पूर्ण इंटरैक्टिव ग्राफ़ देखने के लिए `.rpgkit/data/rpg.html` खोलें।
 
 ![RPG-Kit repository graph visualization](../docs/rpgkit_visualized_graph.png)
 
-## Installation
+## इंस्टॉलेशन
 
 ### पूर्वापेक्षाएँ
 
 - Python 3.12+
 - [uv](https://docs.astral.sh/uv/)
 - Git
-- installed और authenticated AI coding agent CLI: [GitHub Copilot](https://docs.github.com/en/copilot) या [Claude Code](https://docs.anthropic.com/en/docs/claude-code/setup)
+- एक इंस्टॉल और प्रमाणित AI कोडिंग एजेंट CLI: [GitHub Copilot](https://docs.github.com/en/copilot) या [Claude Code](https://docs.anthropic.com/en/docs/claude-code/setup)
 
-### RPG-Kit install करें
+### RPG-Kit इंस्टॉल करें
 
 ```bash
-# Persistent installation (Recommended)
+# Persistent इंस्टॉलेशन (अनुशंसित)
 uv tool install rpgkit-cli --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-Kit"
 rpgkit check
 
-# One-time usage
+# एक बार के उपयोग के लिए
 uvx --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-Kit" rpgkit init <project-name>
 ```
 
-<a id="quick-start-new-repository"></a>
+## Quick Start: नई रिपॉज़िटरी
 
-## Quick Start: नया Repository
-
-जब आप चाहते हैं कि RPG-Kit requirements को एक नए codebase में बदले, तो इस path का उपयोग करें।
+जब आप RPG-Kit से आवश्यकताओं को एक नए कोडबेस में बदलवाना चाहते हैं, तब इस मार्ग का उपयोग करें।
 
 > [!WARNING]
-> जिन projects में generated code की मात्रा बड़ी हो, उनमें `/rpgkit.design_interfaces` और `/rpgkit.code_gen` का runtime लंबा हो सकता है। एक typical example: feature count 100 होने पर runtime लगभग 30 minutes होता है।
+> बहुत अधिक जनरेटेड कोड वाली परियोजनाओं के लिए, `/rpgkit.design_interfaces` और `/rpgkit.code_gen` को चलने में काफ़ी समय लग सकता है। उदाहरण: 100 features में लगभग 30 मिनट लगते हैं।
 
-1. नया project initialize करें:
+1. नई परियोजना को आरंभीकृत करें:
 
    ```bash
    rpgkit init my-project
    cd my-project
    ```
 
-   सामान्य variants:
+   सामान्य विकल्प:
 
    ```bash
    rpgkit init my-project --ai claude --script sh
@@ -82,11 +125,11 @@ uvx --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-K
    rpgkit init my-project --github-token $GITHUB_TOKEN
    ```
 
-2. **[Optional]** अपनी requirement documents को `my-project/docs/` में रखें।
+2. **[वैकल्पिक]** अपने आवश्यकता दस्तावेज़ `my-project/docs/` में रखें।
 
-3. project directory में अपना AI coding agent launch करें।
+3. परियोजना निर्देशिका में अपना AI कोडिंग एजेंट लॉन्च करें।
 
-4. forward pipeline run करें:
+4. फॉरवर्ड पाइपलाइन चलाएँ:
 
    ```text
    /rpgkit.feature_spec <feature description>
@@ -102,18 +145,16 @@ uvx --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-K
    [Optional] /rpgkit.rpg_edit <edit instructions>
    ```
 
-RPG-Kit क्रमिक रूप से `.rpgkit/data/rpg.json` बनाता है और इसका उपयोग requirements, planning artifacts, generated code, और dependency information को aligned रखने के लिए करता है।
+RPG-Kit क्रमिक रूप से `.rpgkit/data/rpg.json` बनाता है और इसका उपयोग आवश्यकताओं, प्लानिंग आउटपुट, जनरेटेड कोड और dependency जानकारी को संरेखित रखने के लिए करता है।
 
-<a id="quick-start-existing-repository"></a>
+## Quick Start: मौजूदा रिपॉज़िटरी
 
-## Quick Start: मौजूदा Repository
-
-जब आपके पास पहले से repository हो और आप चाहते हों कि AI agent उसे RPG context के साथ समझे या edit करे, तो इस path का उपयोग करें।
+जब आपके पास पहले से एक रिपॉज़िटरी है और आप चाहते हैं कि AI एजेंट इसे RPG कॉन्टेक्स्ट के साथ समझे या संपादित करे, तब इस मार्ग का उपयोग करें।
 
 > [!WARNING]
-> बड़े projects के लिए, `rpgkit init . --encode` और `/rpgkit.encode` का runtime लंबा हो सकता है। एक typical example: source code files 200 होने पर runtime 100 minutes होता है।
+> बड़ी परियोजनाओं के लिए, `rpgkit init . --encode` और `/rpgkit.encode` को चलने में काफ़ी समय लग सकता है। उदाहरण: 200 स्रोत फ़ाइलों में लगभग 100 मिनट लगते हैं।
 
-1. repository root में RPG-Kit initialize करें और initial graph build करें:
+1. रिपॉज़िटरी रूट में RPG-Kit को आरंभीकृत करें और प्रारंभिक ग्राफ़ बनाएँ:
 
    ```bash
    mkdir my-project
@@ -122,81 +163,81 @@ RPG-Kit क्रमिक रूप से `.rpgkit/data/rpg.json` बनात
    rpgkit init . --encode
    ```
 
-   अगर आप non-empty directory के confirmation prompt को skip करना चाहते हैं:
+   यदि आप गैर-खाली निर्देशिका के लिए पुष्टि संकेत को छोड़ना चाहते हैं:
 
    ```bash
    rpgkit init . --force --encode
    ```
 
-2. repository में अपना AI coding agent launch करें।
+2. रिपॉज़िटरी में अपना AI कोडिंग एजेंट लॉन्च करें।
 
-3. generated RPG को MCP tools और slash commands के माध्यम से उपयोग करें:
+3. MCP टूल्स और स्लैश कमांड्स के माध्यम से जनरेटेड RPG का उपयोग करें:
 
    ```text
-   /rpgkit.encode                                  # जरूरत पड़ने पर full RPG rebuild करें
-   /rpgkit.update_rpg                              # manual incremental update fallback
-   /rpgkit.rpg_edit <edit instructions>            # graph-aware code edit
+   /rpgkit.encode                                  # आवश्यकता पड़ने पर पूर्ण RPG को पुनर्निर्मित करें
+   /rpgkit.update_rpg                              # मैन्युअल वृद्धिशील अपडेट (fallback)
+   /rpgkit.rpg_edit <edit instructions>            # ग्राफ़-जागरूक कोड संपादन
    ```
 
-4. commits के बाद, RPG-Kit hooks `.rpgkit/data/rpg.json`, `.rpgkit/data/dep_graph.json`, और `.rpgkit/data/rpg.html` को code changes के साथ aligned रखते हैं। अगर hook fail या skip हो जाए, तो `/rpgkit.update_rpg` run करें।
+4. कमिट के बाद, RPG-Kit hooks `.rpgkit/data/rpg.json`, `.rpgkit/data/dep_graph.json` और `.rpgkit/data/rpg.html` को कोड परिवर्तनों के साथ संरेखित रखते हैं। यदि hook विफल हो जाता है या छोड़ दिया जाता है, तो `/rpgkit.update_rpg` चलाएँ।
 
-## क्या जोड़ा जाता है
+## `rpgkit init` के बाद क्या होता है
 
-`rpgkit init` run करने के बाद भी workspace root आपके project repository का root रहता है। RPG-Kit command definitions, runtime scripts, MCP configuration, और generated graph data को आपके code के साथ जोड़ता है।
+`rpgkit init` आपकी स्रोत फ़ाइलों को संशोधित नहीं करता है। यह आपके कोड के साथ-साथ कमांड परिभाषाएँ, रनटाइम स्क्रिप्ट्स, MCP कॉन्फ़िगरेशन और जनरेटेड ग्राफ़ डेटा जोड़ता है।
 
 ```text
 my-project/
-├── docs/                 # /rpgkit.feature_spec के लिए optional requirement docs
-├── .github/ or .claude/  # AI assistant command definitions और settings
-├── .vscode/              # applicable होने पर Copilot/VS Code MCP configuration
-└── .rpgkit/              # RPG-Kit runtime
-    ├── scripts/          # Pipeline scripts और support packages
-    ├── data/             # Generated artifacts, जिनमें rpg.json और dep_graph.json शामिल हैं
-    ├── logs/             # Per-stage execution logs
-    └── reports/          # Generated review और diagnostic reports
+├── docs/                 # /rpgkit.feature_spec के लिए वैकल्पिक आवश्यकता दस्तावेज़
+├── .github/ or .claude/  # AI सहायक कमांड परिभाषाएँ और सेटिंग्स
+├── .vscode/              # लागू होने पर Copilot/VS Code MCP कॉन्फ़िगरेशन
+└── .rpgkit/              # RPG-Kit रनटाइम
+    ├── scripts/          # पाइपलाइन स्क्रिप्ट्स और सहायक पैकेज
+    ├── data/             # जनरेटेड आउटपुट, जिसमें rpg.json और dep_graph.json शामिल हैं
+    ├── logs/             # प्रति-चरण निष्पादन लॉग
+    └── reports/          # जनरेट होने पर समीक्षा और निदान रिपोर्ट
 ```
 
-Full layout और data file reference के लिए [docs/project-structure.md](docs/project-structure.md) देखें।
+पूर्ण लेआउट और डेटा फ़ाइल संदर्भ के लिए [docs/project-structure.md](docs/project-structure.md) देखें।
 
-## Supported Platforms
+## समर्थित प्लेटफ़ॉर्म्स
 
-| प्लेटफ़ॉर्म             | Claude Code | GitHub Copilot | Codex |
-| ----------------------- | ----------- | -------------- | ----- |
-| CLI उपयोग               | ✅          | ✅(MCP नहीं)   | ⌛    |
-| VS Code extension उपयोग | ✅          | ✅             | ⌛    |
+| प्लेटफ़ॉर्म              | Claude Code | GitHub Copilot | Codex |
+| ------------------------ | ----------- | -------------- | ----- |
+| CLI उपयोग                | ✅          | ✅ (No MCP)    | ⌛    |
+| VS Code एक्सटेंशन उपयोग  | ✅          | ✅             | ⌛    |
 
-| Script | Linux | Windows | Mac |
-| ------ | ----- | ------- | --- |
-| sh     | ✅    | ⌛      | ⌛  |
-| ps     | N/A   | ⌛      | ⌛  |
+| स्क्रिप्ट | Linux | Windows | Mac |
+| --------- | ----- | ------- | --- |
+| sh        | ✅    | ⌛      | ⌛  |
+| ps        | N/A   | ⌛      | ⌛  |
 
-## Documentation
+## दस्तावेज़ीकरण
 
-- [Slash command reference](docs/commands.md) — हर `/rpgkit.*` command, inputs, outputs, और examples।
-- [CLI reference](docs/cli-reference.md) — `rpgkit init`, `rpgkit update`, `rpgkit check`, `rpgkit version`, और सभी options।
-- [Configuration](docs/configuration.md) — AI assistant setup, MCP registration, hooks, auto-approval, और troubleshooting।
-- [Project structure](docs/project-structure.md) — RPG-Kit द्वारा बनाए गए files और directories।
+- [स्लैश कमांड संदर्भ](docs/commands.md) — हर `/rpgkit.*` कमांड के लिए इनपुट, आउटपुट और उदाहरण।
+- [CLI संदर्भ](docs/cli-reference.md) — `rpgkit init`, `rpgkit update`, `rpgkit check`, `rpgkit version` और सभी विकल्प।
+- [कॉन्फ़िगरेशन](docs/configuration.md) — AI सहायक सेटअप, MCP पंजीकरण, hooks, ऑटो-अनुमोदन और समस्या-निवारण।
+- [परियोजना संरचना](docs/project-structure.md) — RPG-Kit द्वारा बनाई गई फ़ाइलें और निर्देशिकाएँ।
 
-## आगामी फीचर्स
+## आगामी सुविधाएँ
 
-- **सरल decoder commands:** मौजूदा decoder flow को कम commands में merge करना, जिसमें end-to-end repository generation के लिए `/rpgkit.generate_repo`, और feature generation तथा RPG planning के लिए `/rpgkit.generate_feature` plus `/rpgkit.plan` शामिल हैं।
-- **Multi-language support:** Go, C++, Rust, JavaScript/TypeScript, और अन्य के लिए support जोड़ना।
-- **अधिक platform integrations:** अलग-अलग systems पर अलग-अलग AI coding agents के लिए CLI और VS Code extension workflows में RPG-Kit support करना।
+- **सरल जनरेशन कमांड्स:** वर्तमान बहु-चरण जनरेशन प्रवाह को कम कमांड्स में मर्ज किया जाएगा, जैसे `/rpgkit.generate_repo`, `/rpgkit.generate_feature` और `/rpgkit.plan`।
+- **बहु-भाषा समर्थन:** Go, C++, Rust, JavaScript/TypeScript और अन्य के लिए समर्थन जोड़ा जाएगा।
+- **अधिक प्लेटफ़ॉर्म एकीकरण:** विभिन्न सिस्टम्स पर विभिन्न AI कोडिंग एजेंट्स के लिए CLI और VS Code एक्सटेंशन वर्कफ़्लो में RPG-Kit समर्थन।
 
-## Troubleshooting
+## समस्या-निवारण
 
-**AI assistant CLI नहीं मिला:** `rpgkit check` run करें, selected assistant CLI install और authenticate करें, फिर `rpgkit init` या `rpgkit update` दोबारा run करें।
+**AI सहायक CLI नहीं मिला:** `rpgkit check` चलाएँ, चयनित सहायक CLI को इंस्टॉल और प्रमाणित करें, फिर `rpgkit init` या `rpgkit update` पुनः चलाएँ।
 
-**MCP tools `rpg_unavailable` report करते हैं:** `.rpgkit/data/rpg.json` create करने के लिए `/rpgkit.encode` run करें।
+**MCP टूल्स `rpg_unavailable` की रिपोर्ट करते हैं:** `.rpgkit/data/rpg.json` बनाने के लिए `/rpgkit.encode` चलाएँ।
 
-**Incremental update failed:** `.rpgkit/logs/update_rpg.log` inspect करें, फिर `/rpgkit.update_rpg` run करें।
+**वृद्धिशील अपडेट विफल:** `.rpgkit/logs/update_rpg.log` की जाँच करें, फिर `/rpgkit.update_rpg` चलाएँ।
 
-**Rate limits या private repo access के कारण template download fail होता है:** `--github-token $GITHUB_TOKEN` pass करें या `GH_TOKEN` / `GITHUB_TOKEN` set करें।
+**रेट लिमिट्स या निजी रिपॉज़िटरी एक्सेस के कारण टेम्पलेट डाउनलोड विफल:** `--github-token $GITHUB_TOKEN` पास करें या `GH_TOKEN` / `GITHUB_TOKEN` सेट करें।
 
-## License
+## लाइसेंस
 
-MIT License - विवरण के लिए [LICENSE](LICENSE) देखें।
+MIT License — विवरण के लिए [LICENSE](LICENSE) देखें।
 
-## Acknowledgements
+## आभार
 
 [GitHub Spec-Kit](https://github.com/github/spec-kit) पर आधारित।

--- a/RPG-Kit/README.ja-JP.md
+++ b/RPG-Kit/README.ja-JP.md
@@ -8,35 +8,80 @@
   <a href="README.hi-IN.md">हिन्दी</a>
 </p>
 
-## AI コーディングエージェントにリポジトリ全体を理解させる
+## コーディングエージェントに、編集する前にプランを立てさせる
 
-AI コーディングエージェントは強力ですが、多くの場合、ファイル単位で作業します。プロジェクトが成長すると、要件、アーキテクチャ、依存関係、過去の設計判断を見失うことがあります。
+コーディングエージェントはローカルな編集には強いものの、リポジトリレベルのタスクは安定した計画構造がないと失敗しがちです。要件はドリフトし、アーキテクチャ上の判断は失われ、複数ファイルにまたがる生成は一貫性を欠き、更新は隠れた依存関係を見落とすことがあります。
 
-RPG-Kit は **Repository Planning Graph (RPG)** を維持することで、この問題の解決を支援します。RPG は、要件、機能、ファイル、コンポーネント、依存関係を接続する構造化されたマップです。
+RPG-Kit は Claude Code と GitHub Copilot に、リポジトリレベルのコーディングのための**永続的な RPG ワークスペース**を提供します。このワークスペースは、要件・機能・アーキテクチャ・ファイル・コードエンティティ・依存関係をつなぐ **Repository Planning Graph (RPG)** を中心に構成されています。
 
-孤立したプロンプトではなく、リポジトリレベルのコンテキストで AI エージェントに作業させたい場合に RPG-Kit を使用します。
+RPG-Kit を使うと、エージェントはグラフ駆動のワークフローで作業できます:
 
-### RPG-Kit を使う理由
+- **Build（構築）**: 要件を RPG プランに変換し、複数ファイルからなるリポジトリを生成する。
+- **Understand（理解）**: 既存のリポジトリを RPG にマッピングし、検索・探索・説明する。
+- **Update（更新）**: 影響を受ける RPG ノードを特定し、編集プランを立て、コードとグラフを同時に更新する。
 
-| AI コーディングエージェントによくある問題 | RPG-Kit による解決 |
-|---|---|
-| 数回のプロンプトの後にエージェントが要件を忘れる | 要件が RPG にエンコードされます |
-| 関連ファイルを理解せずに 1 つのファイルだけを編集する | ファイル、コンポーネント、依存関係がグラフで接続されます |
-| 生成されたコードが元の計画からずれていく | 計画成果物とコードが整合した状態に保たれます |
-| 既存リポジトリをエージェントが理解しにくい | コードベースを RPG にエンコードできます |
-| 対象を絞った編集が隠れた依存関係を壊す可能性がある | グラフ認識型のコンテキストで編集されます |
+### ワークフローを選ぶ
 
-### ワークフローを選択する
-
-| 目的 | ワークフロー | ここから開始 |
+| 目的 | ワークフロー | ここから始める |
 |---|---|---|
-| 要件から新しいプロジェクトを作成する | 順方向ワークフロー | [`クイックスタート：新規リポジトリ`](#quick-start-new-repository) |
-| 既存のコードベースを理解または更新する | 逆方向ワークフロー | [`クイックスタート：既存リポジトリ`](#quick-start-existing-repository) |
-| 正確なリポジトリ認識型編集を行う | 外科的編集ワークフロー | [`クイックスタート：既存リポジトリ`](#quick-start-existing-repository) |
+| 要件から新しいリポジトリを構築する | Build ワークフロー（requirements → RPG → code） | [`クイックスタート: 新規リポジトリ`](#クイックスタート-新規リポジトリ) |
+| 既存のリポジトリを理解する | Understand ワークフロー（repository → RPG → search/explore） | [`クイックスタート: 既存リポジトリ`](#クイックスタート-既存リポジトリ) |
+| 既存のリポジトリを更新する | Update ワークフロー（change request → affected RPG nodes → edit plan → code/RPG update） | [`クイックスタート: 既存リポジトリ`](#クイックスタート-既存リポジトリ) |
 
-以下は、このリポジトリ用に生成されたグラフ可視化の一部です。`/rpgkit.encode` を実行し、`rpg.html` を開くと、完全なインタラクティブグラフを探索できます。
+### 詳細なパイプライン
 
-![RPG-Kit リポジトリグラフ可視化](../docs/rpgkit_visualized_graph.png)
+初めて使う方は、このセクションを飛ばして下のクイックスタートから始められます。
+
+<details>
+<summary>コマンドレベルの完全なワークフロー図</summary>
+
+```text
+Forward Direction: Requirements → RPG → Code
+
+ Phase 1: Feature Specification       Phase 2: RPG Construction & Planning                             Phase 3
+┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
+│ feature  │ │ feature  │ │ feature  │ │  build   │ │  build   │ │ design   │ │ design   │ │  plan    │ │          │
+│  _spec   ├─▶  _build  ├─▶_refactor ├─▶ skeleton ├─▶  data    ├─▶  base    ├─▶interfaces├─▶  tasks  ├─▶ code_gen │
+│          │ │          │ │          │ │          │ │  flow    │ │ classes  │ │          │ │          │ │   (TDD)  │
+└──────────┘ └──────────┘ └────┬─────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘ └────┬─────┘
+ feature_     feature_        │        skeleton     data_flow    base_        interfaces   tasks        source
+ spec/        build           │        .json        .json        classes      .json        .json        code
+ feature_     .json           │        skeleton_    data_flow    .json
+ spec.json                    │        summary.txt  _viz.html
+                              │
+                       ┌──────▼──────┐
+                       │ feature_edit│ optional pre-planning edits to feature_tree.json
+                       └─────────────┘
+                                        ╰───── rpg.json (created → progressively enriched) ─────╯
+                                                                            │
+                                                                            ▼
+                                                                     ┌──────────┐
+Surgical edit workflow: Requirements -> RPG update -> Code Update    │ rpg_edit │ optional synchronized RPG + code + dep_graph edits
+                                                                     └──▲────▲──┘
+                                                                        │    │
+Reverse Direction: Code → RPG                                           │    │
+                                                                        │    │
+┌──────────────────┐         ┌──────────┐       ┌──────────┐            │    │
+│ Existing Codebase│────────▶│  encode  │──────▶│update_rpg│────────────┘    │
+│                  │         │  (full)  │       │ (manual  │                 │
+└──────────────────┘         └────┬─────┘       │ fallback)│                 │
+                              rpg.json          └──────────┘                 │
+                              dep_graph.json     rpg.json / dep_graph.json   │
+                                  │                                          │
+                                  └──────────────────────────────────────────┘
+                                                  ▲
+                                                  │ post-commit hook normally runs incremental updates
+
+MCP Server: search_rpg / explore_rpg / get_node_detail / list_rpg_tree
+```
+
+</details>
+
+### RPG-Kit の実例
+
+下の図は、本リポジトリに対して生成されたグラフ可視化の一部です。`/rpgkit.encode` を実行し、`.rpgkit/data/rpg.html` を開くと完全なインタラクティブグラフを閲覧できます。
+
+![RPG-Kit repository graph visualization](../docs/rpgkit_visualized_graph.png)
 
 ## インストール
 
@@ -45,36 +90,34 @@ RPG-Kit は **Repository Planning Graph (RPG)** を維持することで、こ�
 - Python 3.12+
 - [uv](https://docs.astral.sh/uv/)
 - Git
-- インストール済みで認証済みの AI コーディングエージェント CLI：[GitHub Copilot](https://docs.github.com/en/copilot) または [Claude Code](https://docs.anthropic.com/en/docs/claude-code/setup)
+- インストール済みで認証済みの AI コーディングエージェント CLI: [GitHub Copilot](https://docs.github.com/en/copilot) または [Claude Code](https://docs.anthropic.com/en/docs/claude-code/setup)
 
-### RPG-Kit をインストールする
+### RPG-Kit のインストール
 
 ```bash
 # 永続インストール（推奨）
 uv tool install rpgkit-cli --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-Kit"
 rpgkit check
 
-# 一回限りの使用
+# 一度きりの使用
 uvx --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-Kit" rpgkit init <project-name>
 ```
 
-<a id="quick-start-new-repository"></a>
+## クイックスタート: 新規リポジトリ
 
-## クイックスタート：新規リポジトリ
-
-RPG-Kit に要件を新しいコードベースへ変換させたい場合は、この手順を使用します。
+要件から新しいコードベースを生成したい場合は、こちらの手順を使います。
 
 > [!WARNING]
-> 生成されるコード量が多いプロジェクトでは、`/rpgkit.design_interfaces` と `/rpgkit.code_gen` の実行時間が長くなる場合があります。典型的な例として、機能数が 100 の場合、実行時間は約 30 分です。
+> 生成コード量が多いプロジェクトでは、`/rpgkit.design_interfaces` と `/rpgkit.code_gen` の実行に時間がかかることがあります。例として、100 個の feature でおおよそ 30 分かかります。
 
-1. 新しいプロジェクトを初期化します：
+1. 新しいプロジェクトを初期化します:
 
    ```bash
    rpgkit init my-project
    cd my-project
    ```
 
-   一般的なバリエーション：
+   よく使うバリエーション:
 
    ```bash
    rpgkit init my-project --ai claude --script sh
@@ -86,7 +129,7 @@ RPG-Kit に要件を新しいコードベースへ変換させたい場合は、
 
 3. プロジェクトディレクトリで AI コーディングエージェントを起動します。
 
-4. 順方向パイプラインを実行します：
+4. フォワードパイプラインを実行します:
 
    ```text
    /rpgkit.feature_spec <feature description>
@@ -102,18 +145,16 @@ RPG-Kit に要件を新しいコードベースへ変換させたい場合は、
    [Optional] /rpgkit.rpg_edit <edit instructions>
    ```
 
-RPG-Kit は `.rpgkit/data/rpg.json` を段階的に作成し、それを使用して要件、計画成果物、生成されたコード、依存関係情報の整合性を保ちます。
+RPG-Kit は `.rpgkit/data/rpg.json` を段階的に作成し、それを使って要件・計画成果物・生成コード・依存情報を整合した状態に保ちます。
 
-<a id="quick-start-existing-repository"></a>
+## クイックスタート: 既存リポジトリ
 
-## クイックスタート：既存リポジトリ
-
-すでにリポジトリがあり、AI エージェントに RPG コンテキストを使って理解または編集させたい場合は、この手順を使用します。
+すでにリポジトリがあり、AI エージェントに RPG コンテキストで理解または編集させたい場合は、こちらの手順を使います。
 
 > [!WARNING]
-> 比較的大きなプロジェクトでは、`rpgkit init . --encode` と `/rpgkit.encode` の実行時間が長くなる場合があります。典型的な例として、ソースコードファイル数が 200 の場合、実行時間は約 100 分です。
+> 大きめのプロジェクトでは、`rpgkit init . --encode` と `/rpgkit.encode` の実行に時間がかかることがあります。例として、200 ファイルでおおよそ 100 分かかります。
 
-1. リポジトリルートで RPG-Kit を初期化し、初期グラフを構築します：
+1. リポジトリのルートで RPG-Kit を初期化し、初期グラフを構築します:
 
    ```bash
    mkdir my-project
@@ -122,48 +163,48 @@ RPG-Kit は `.rpgkit/data/rpg.json` を段階的に作成し、それを使用�
    rpgkit init . --encode
    ```
 
-   空でないディレクトリの確認プロンプトをスキップしたい場合：
+   空でないディレクトリでの確認プロンプトをスキップしたい場合:
 
    ```bash
    rpgkit init . --force --encode
    ```
 
-2. リポジトリ内で AI コーディングエージェントを起動します。
+2. リポジトリで AI コーディングエージェントを起動します。
 
-3. MCP ツールとスラッシュコマンドを通じて、生成された RPG を使用します：
+3. 生成された RPG を MCP ツールおよびスラッシュコマンド経由で利用します:
 
    ```text
    /rpgkit.encode                                  # 必要に応じて完全な RPG を再構築
-   /rpgkit.update_rpg                              # 手動インクリメンタル更新のフォールバック
-   /rpgkit.rpg_edit <edit instructions>            # グラフ認識型コード編集
+   /rpgkit.update_rpg                              # 手動の増分更新（フォールバック）
+   /rpgkit.rpg_edit <edit instructions>            # グラフ認識型のコード編集
    ```
 
-4. コミット後、RPG-Kit hooks は `.rpgkit/data/rpg.json`、`.rpgkit/data/dep_graph.json`、`.rpgkit/data/rpg.html` をコード変更と整合させます。hook が失敗またはスキップされた場合は、`/rpgkit.update_rpg` を実行してください。
+4. コミット後、RPG-Kit のフックが `.rpgkit/data/rpg.json`、`.rpgkit/data/dep_graph.json`、`.rpgkit/data/rpg.html` をコード変更に合わせて整合します。フックが失敗したりスキップされた場合は `/rpgkit.update_rpg` を実行してください。
 
-## 追加されるもの
+## `rpgkit init` の後に起きること
 
-`rpgkit init` の実行後も、workspace root はプロジェクトリポジトリのルートのままです。RPG-Kit は、コマンド定義、ランタイムスクリプト、MCP 設定、生成されたグラフデータをコードと並べて追加します。
+`rpgkit init` はソースファイルを変更しません。コードのそばに、コマンド定義・ランタイムスクリプト・MCP 設定・生成されたグラフデータを追加します。
 
 ```text
 my-project/
 ├── docs/                 # /rpgkit.feature_spec 用の任意の要件ドキュメント
-├── .github/ or .claude/  # AI assistant コマンド定義と設定
+├── .github/ or .claude/  # AI アシスタントのコマンド定義と設定
 ├── .vscode/              # 該当する場合の Copilot/VS Code MCP 設定
 └── .rpgkit/              # RPG-Kit ランタイム
-    ├── scripts/          # パイプラインスクリプトとサポートパッケージ
-    ├── data/             # rpg.json と dep_graph.json を含む生成アーティファクト
+    ├── scripts/          # パイプラインスクリプトおよびサポートパッケージ
+    ├── data/             # 生成成果物（rpg.json と dep_graph.json を含む）
     ├── logs/             # ステージごとの実行ログ
-    └── reports/          # 生成されたレビューおよび診断レポート
+    └── reports/          # 生成時のレビュー・診断レポート
 ```
 
-完全なレイアウトとデータファイルリファレンスについては、[docs/project-structure.md](docs/project-structure.md) を参照してください。
+完全なレイアウトとデータファイルのリファレンスは [docs/project-structure.md](docs/project-structure.md) を参照してください。
 
-## サポートされるプラットフォーム
+## 対応プラットフォーム
 
-| プラットフォーム        | Claude Code | GitHub Copilot | Codex |
-| ----------------------- | ----------- | -------------- | ----- |
-| CLI 使用                | ✅          | ✅(MCP なし)   | ⌛    |
-| VS Code 拡張の使用      | ✅          | ✅             | ⌛    |
+| プラットフォーム      | Claude Code | GitHub Copilot | Codex |
+| --------------------- | ----------- | -------------- | ----- |
+| CLI 使用              | ✅          | ✅ (No MCP)    | ⌛    |
+| VS Code 拡張使用      | ✅          | ✅             | ⌛    |
 
 | スクリプト | Linux | Windows | Mac |
 | ---------- | ----- | ------- | --- |
@@ -172,31 +213,31 @@ my-project/
 
 ## ドキュメント
 
-- [スラッシュコマンドリファレンス](docs/commands.md) — すべての `/rpgkit.*` コマンド、入力、出力、例。
-- [CLI リファレンス](docs/cli-reference.md) — `rpgkit init`、`rpgkit update`、`rpgkit check`、`rpgkit version`、およびすべてのオプション。
-- [設定](docs/configuration.md) — AI assistant のセットアップ、MCP 登録、hooks、自動承認、トラブルシューティング。
+- [スラッシュコマンドリファレンス](docs/commands.md) — すべての `/rpgkit.*` コマンドの入力・出力・例。
+- [CLI リファレンス](docs/cli-reference.md) — `rpgkit init`、`rpgkit update`、`rpgkit check`、`rpgkit version` とすべてのオプション。
+- [設定](docs/configuration.md) — AI アシスタントのセットアップ、MCP 登録、フック、自動承認、およびトラブルシューティング。
 - [プロジェクト構造](docs/project-structure.md) — RPG-Kit が作成するファイルとディレクトリ。
 
 ## 今後の機能
 
-- **よりシンプルなデコーダーコマンド：** 現在のデコーダーフローをより少ないコマンドに統合します。これには、エンドツーエンドのリポジトリ生成用の `/rpgkit.generate_repo`、および機能生成と RPG 計画用の `/rpgkit.generate_feature` と `/rpgkit.plan` が含まれます。
-- **多言語サポート：** Go、C++、Rust、JavaScript/TypeScript などのサポートを追加します。
-- **より多くのプラットフォーム統合：** さまざまなシステム上で、異なる AI コーディングエージェント向けに CLI と VS Code 拡張ワークフローで RPG-Kit をサポートします。
+- **よりシンプルな生成コマンド:** 現在の多段階の生成フローを、`/rpgkit.generate_repo`、`/rpgkit.generate_feature`、`/rpgkit.plan` などのより少ないコマンドにまとめます。
+- **多言語サポート:** Go、C++、Rust、JavaScript/TypeScript などのサポートを追加します。
+- **より多くのプラットフォーム連携:** さまざまなシステム上の異なる AI コーディングエージェントについて、CLI と VS Code 拡張ワークフローを横断して RPG-Kit をサポートします。
 
 ## トラブルシューティング
 
-**AI assistant CLI が見つからない：** `rpgkit check` を実行し、選択した assistant CLI をインストールして認証したうえで、`rpgkit init` または `rpgkit update` を再実行します。
+**AI アシスタント CLI が見つからない:** `rpgkit check` を実行し、選択したアシスタント CLI をインストールおよび認証し、`rpgkit init` または `rpgkit update` を再実行してください。
 
-**MCP ツールが `rpg_unavailable` を報告する：** `/rpgkit.encode` を実行して `.rpgkit/data/rpg.json` を作成します。
+**MCP ツールが `rpg_unavailable` を報告する:** `/rpgkit.encode` を実行して `.rpgkit/data/rpg.json` を作成してください。
 
-**インクリメンタル更新に失敗した：** `.rpgkit/logs/update_rpg.log` を確認し、その後 `/rpgkit.update_rpg` を実行します。
+**増分更新が失敗する:** `.rpgkit/logs/update_rpg.log` を確認し、`/rpgkit.update_rpg` を実行してください。
 
-**レート制限またはプライベートリポジトリアクセスによりテンプレートのダウンロードに失敗する：** `--github-token $GITHUB_TOKEN` を渡すか、`GH_TOKEN` / `GITHUB_TOKEN` を設定します。
+**レート制限またはプライベートリポジトリのアクセス権でテンプレートのダウンロードに失敗する:** `--github-token $GITHUB_TOKEN` を渡すか、`GH_TOKEN` / `GITHUB_TOKEN` を設定してください。
 
 ## ライセンス
 
-MIT License - 詳細は [LICENSE](LICENSE) を参照してください。
+MIT License — 詳細は [LICENSE](LICENSE) を参照してください。
 
 ## 謝辞
 
-[GitHub Spec-Kit](https://github.com/github/spec-kit) に基づいています。
+[GitHub Spec-Kit](https://github.com/github/spec-kit) を基にしています。

--- a/RPG-Kit/README.ko-KR.md
+++ b/RPG-Kit/README.ko-KR.md
@@ -8,39 +8,84 @@
   <a href="README.hi-IN.md">हिन्दी</a>
 </p>
 
-## AI 코딩 에이전트가 전체 리포지토리를 이해하도록 하기
+## 코딩 에이전트가 편집하기 전에 계획을 세우게 하세요
 
-AI 코딩 에이전트는 강력하지만, 대개 파일 단위로 작업합니다. 프로젝트가 커질수록 요구사항, 아키텍처, 의존성, 이전 설계 결정을 놓칠 수 있습니다.
+코딩 에이전트는 로컬 편집에는 강하지만, 안정적인 계획 구조가 없으면 저장소 수준의 작업은 실패하기 쉽습니다. 요구사항이 흐트러지고, 아키텍처 결정이 사라지고, 여러 파일에 걸친 생성이 일관성을 잃으며, 업데이트가 숨겨진 의존성을 놓칠 수 있습니다.
 
-RPG-Kit은 **Repository Planning Graph (RPG)** 를 유지하여 이 문제를 해결하도록 돕습니다. RPG는 요구사항, 기능, 파일, 컴포넌트, 의존성을 연결하는 구조화된 지도입니다.
+RPG-Kit은 Claude Code와 GitHub Copilot에 저장소 수준의 코딩을 위한 **영속적인 RPG 워크스페이스**를 제공합니다. 이 워크스페이스는 요구사항, 기능, 아키텍처, 파일, 코드 엔티티, 의존성을 연결하는 **Repository Planning Graph (RPG)** 를 중심으로 구성되어 있습니다.
 
-고립된 프롬프트 대신 리포지토리 수준의 컨텍스트로 AI 에이전트가 작업하기를 원할 때 RPG-Kit을 사용하세요.
+RPG-Kit을 사용하면 에이전트는 그래프 기반 워크플로로 작업할 수 있습니다:
 
-### 왜 RPG-Kit인가요?
-
-| AI 코딩 에이전트의 일반적인 문제 | RPG-Kit의 도움 방식 |
-|---|---|
-| 에이전트가 몇 번의 프롬프트 후 요구사항을 잊어버림 | 요구사항이 RPG에 인코딩됩니다 |
-| 관련 파일을 이해하지 못한 채 한 파일만 편집함 | 파일, 컴포넌트, 의존성이 그래프에서 연결됩니다 |
-| 생성된 코드가 원래 계획에서 벗어남 | 계획 산출물과 코드가 정렬된 상태로 유지됩니다 |
-| 기존 리포지토리를 에이전트가 이해하기 어려움 | 코드베이스를 RPG로 인코딩할 수 있습니다 |
-| 대상이 명확한 편집이 숨겨진 의존성을 깨뜨릴 수 있음 | 그래프 인식 컨텍스트로 편집됩니다 |
+- **Build (구축)**: 요구사항을 RPG 계획으로 바꾼 다음 여러 파일로 구성된 저장소를 생성합니다.
+- **Understand (이해)**: 기존 저장소를 RPG로 매핑한 다음 검색, 탐색, 설명합니다.
+- **Update (업데이트)**: 영향을 받는 RPG 노드를 식별하고, 편집 계획을 세우고, 코드와 그래프를 함께 업데이트합니다.
 
 ### 워크플로 선택
 
 | 목표 | 워크플로 | 시작 위치 |
 |---|---|---|
-| 요구사항에서 새 프로젝트 생성 | 정방향 워크플로 | [`빠른 시작: 새 리포지토리`](#quick-start-new-repository) |
-| 기존 코드베이스 이해 또는 업데이트 | 역방향 워크플로 | [`빠른 시작: 기존 리포지토리`](#quick-start-existing-repository) |
-| 정밀한 리포지토리 인식 편집 수행 | 외과적 편집 워크플로 | [`빠른 시작: 기존 리포지토리`](#quick-start-existing-repository) |
+| 요구사항으로 새 저장소 구축 | Build 워크플로 (requirements → RPG → code) | [`Quick Start: 새 저장소`](#quick-start-새-저장소) |
+| 기존 저장소 이해 | Understand 워크플로 (repository → RPG → search/explore) | [`Quick Start: 기존 저장소`](#quick-start-기존-저장소) |
+| 기존 저장소 업데이트 | Update 워크플로 (change request → affected RPG nodes → edit plan → code/RPG update) | [`Quick Start: 기존 저장소`](#quick-start-기존-저장소) |
 
-아래는 이 리포지토리를 위해 생성된 그래프 시각화의 일부입니다. `/rpgkit.encode`를 실행하고 `rpg.html`을 열어 전체 인터랙티브 그래프를 살펴보세요.
+### 자세한 파이프라인
 
-![RPG-Kit 리포지토리 그래프 시각화](../docs/rpgkit_visualized_graph.png)
+처음 사용하는 사용자는 이 섹션을 건너뛰고 아래의 Quick Start로 바로 시작할 수 있습니다.
+
+<details>
+<summary>커맨드 수준의 전체 워크플로 다이어그램</summary>
+
+```text
+Forward Direction: Requirements → RPG → Code
+
+ Phase 1: Feature Specification       Phase 2: RPG Construction & Planning                             Phase 3
+┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
+│ feature  │ │ feature  │ │ feature  │ │  build   │ │  build   │ │ design   │ │ design   │ │  plan    │ │          │
+│  _spec   ├─▶  _build  ├─▶_refactor ├─▶ skeleton ├─▶  data    ├─▶  base    ├─▶interfaces├─▶  tasks  ├─▶ code_gen │
+│          │ │          │ │          │ │          │ │  flow    │ │ classes  │ │          │ │          │ │   (TDD)  │
+└──────────┘ └──────────┘ └────┬─────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘ └────┬─────┘
+ feature_     feature_        │        skeleton     data_flow    base_        interfaces   tasks        source
+ spec/        build           │        .json        .json        classes      .json        .json        code
+ feature_     .json           │        skeleton_    data_flow    .json
+ spec.json                    │        summary.txt  _viz.html
+                              │
+                       ┌──────▼──────┐
+                       │ feature_edit│ optional pre-planning edits to feature_tree.json
+                       └─────────────┘
+                                        ╰───── rpg.json (created → progressively enriched) ─────╯
+                                                                            │
+                                                                            ▼
+                                                                     ┌──────────┐
+Surgical edit workflow: Requirements -> RPG update -> Code Update    │ rpg_edit │ optional synchronized RPG + code + dep_graph edits
+                                                                     └──▲────▲──┘
+                                                                        │    │
+Reverse Direction: Code → RPG                                           │    │
+                                                                        │    │
+┌──────────────────┐         ┌──────────┐       ┌──────────┐            │    │
+│ Existing Codebase│────────▶│  encode  │──────▶│update_rpg│────────────┘    │
+│                  │         │  (full)  │       │ (manual  │                 │
+└──────────────────┘         └────┬─────┘       │ fallback)│                 │
+                              rpg.json          └──────────┘                 │
+                              dep_graph.json     rpg.json / dep_graph.json   │
+                                  │                                          │
+                                  └──────────────────────────────────────────┘
+                                                  ▲
+                                                  │ post-commit hook normally runs incremental updates
+
+MCP Server: search_rpg / explore_rpg / get_node_detail / list_rpg_tree
+```
+
+</details>
+
+### RPG-Kit 실제 사용 예
+
+아래 이미지는 이 저장소에서 생성된 그래프 시각화의 일부입니다. `/rpgkit.encode` 를 실행하고 `.rpgkit/data/rpg.html` 을 열면 전체 인터랙티브 그래프를 탐색할 수 있습니다.
+
+![RPG-Kit repository graph visualization](../docs/rpgkit_visualized_graph.png)
 
 ## 설치
 
-### 필수 조건
+### 사전 요구사항
 
 - Python 3.12+
 - [uv](https://docs.astral.sh/uv/)
@@ -50,7 +95,7 @@ RPG-Kit은 **Repository Planning Graph (RPG)** 를 유지하여 이 문제를 �
 ### RPG-Kit 설치
 
 ```bash
-# 영구 설치(권장)
+# 영속 설치 (권장)
 uv tool install rpgkit-cli --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-Kit"
 rpgkit check
 
@@ -58,14 +103,12 @@ rpgkit check
 uvx --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-Kit" rpgkit init <project-name>
 ```
 
-<a id="quick-start-new-repository"></a>
+## Quick Start: 새 저장소
 
-## 빠른 시작: 새 리포지토리
-
-RPG-Kit이 요구사항을 새 코드베이스로 변환하도록 하려면 이 경로를 사용하세요.
+요구사항을 새 코드베이스로 만들고 싶을 때 이 경로를 사용하세요.
 
 > [!WARNING]
-> 생성되는 코드 양이 많은 프로젝트의 경우, `/rpgkit.design_interfaces`와 `/rpgkit.code_gen`의 실행 시간이 길어질 수 있습니다. 대표적인 예로, 기능 수가 100개인 경우 실행 시간은 약 30분입니다.
+> 생성 코드 양이 많은 프로젝트의 경우, `/rpgkit.design_interfaces` 와 `/rpgkit.code_gen` 의 실행 시간이 길어질 수 있습니다. 예시: 100개의 feature는 약 30분이 걸립니다.
 
 1. 새 프로젝트를 초기화합니다:
 
@@ -74,7 +117,7 @@ RPG-Kit이 요구사항을 새 코드베이스로 변환하도록 하려면 이 
    cd my-project
    ```
 
-   일반적인 변형:
+   자주 사용하는 변형:
 
    ```bash
    rpgkit init my-project --ai claude --script sh
@@ -82,11 +125,11 @@ RPG-Kit이 요구사항을 새 코드베이스로 변환하도록 하려면 이 
    rpgkit init my-project --github-token $GITHUB_TOKEN
    ```
 
-2. **[선택 사항]** 요구사항 문서를 `my-project/docs/`에 넣습니다.
+2. **[선택]** 요구사항 문서를 `my-project/docs/` 에 둡니다.
 
 3. 프로젝트 디렉터리에서 AI 코딩 에이전트를 실행합니다.
 
-4. 정방향 파이프라인을 실행합니다:
+4. 포워드 파이프라인을 실행합니다:
 
    ```text
    /rpgkit.feature_spec <feature description>
@@ -102,18 +145,16 @@ RPG-Kit이 요구사항을 새 코드베이스로 변환하도록 하려면 이 
    [Optional] /rpgkit.rpg_edit <edit instructions>
    ```
 
-RPG-Kit은 `.rpgkit/data/rpg.json`을 점진적으로 생성하고, 이를 사용해 요구사항, 계획 산출물, 생성된 코드, 의존성 정보를 정렬된 상태로 유지합니다.
+RPG-Kit은 `.rpgkit/data/rpg.json` 을 점진적으로 생성하고, 이를 사용해 요구사항, 계획 산출물, 생성된 코드, 의존성 정보를 정합 상태로 유지합니다.
 
-<a id="quick-start-existing-repository"></a>
+## Quick Start: 기존 저장소
 
-## 빠른 시작: 기존 리포지토리
-
-이미 리포지토리가 있고 AI 에이전트가 RPG 컨텍스트로 이를 이해하거나 편집하게 하려면 이 경로를 사용하세요.
+이미 저장소가 있고, AI 에이전트가 RPG 컨텍스트로 이해하거나 편집하기를 원할 때 이 경로를 사용하세요.
 
 > [!WARNING]
-> 규모가 큰 프로젝트의 경우, `rpgkit init . --encode`와 `/rpgkit.encode`의 실행 시간이 길어질 수 있습니다. 대표적인 예로, 소스 코드 파일 수가 200개인 경우 실행 시간은 약 100분입니다.
+> 큰 프로젝트의 경우, `rpgkit init . --encode` 와 `/rpgkit.encode` 의 실행 시간이 길어질 수 있습니다. 예시: 200개 소스 파일은 약 100분이 걸립니다.
 
-1. 리포지토리 루트에서 RPG-Kit을 초기화하고 초기 그래프를 구축합니다:
+1. 저장소 루트에서 RPG-Kit을 초기화하고 초기 그래프를 생성합니다:
 
    ```bash
    mkdir my-project
@@ -128,42 +169,42 @@ RPG-Kit은 `.rpgkit/data/rpg.json`을 점진적으로 생성하고, 이를 사�
    rpgkit init . --force --encode
    ```
 
-2. 리포지토리에서 AI 코딩 에이전트를 실행합니다.
+2. 저장소에서 AI 코딩 에이전트를 실행합니다.
 
-3. MCP 도구와 slash command를 통해 생성된 RPG를 사용합니다:
+3. MCP 도구와 슬래시 커맨드를 통해 생성된 RPG를 사용합니다:
 
    ```text
    /rpgkit.encode                                  # 필요할 때 전체 RPG 재구축
-   /rpgkit.update_rpg                              # 수동 증분 업데이트 폴백
+   /rpgkit.update_rpg                              # 수동 증분 업데이트 (폴백)
    /rpgkit.rpg_edit <edit instructions>            # 그래프 인식 코드 편집
    ```
 
-4. 커밋 후 RPG-Kit hooks는 `.rpgkit/data/rpg.json`, `.rpgkit/data/dep_graph.json`, `.rpgkit/data/rpg.html`을 코드 변경과 정렬된 상태로 유지합니다. hook이 실패하거나 건너뛰어진 경우 `/rpgkit.update_rpg`를 실행하세요.
+4. 커밋 후, RPG-Kit 훅이 `.rpgkit/data/rpg.json`, `.rpgkit/data/dep_graph.json`, `.rpgkit/data/rpg.html` 을 코드 변경에 맞춰 동기화합니다. 훅이 실패하거나 건너뛰어진 경우 `/rpgkit.update_rpg` 를 실행하세요.
 
-## 추가되는 항목
+## `rpgkit init` 이후 일어나는 일
 
-`rpgkit init`을 실행한 후에도 workspace root는 프로젝트 리포지토리 루트입니다. RPG-Kit은 명령 정의, 런타임 스크립트, MCP 구성, 생성된 그래프 데이터를 코드와 함께 추가합니다.
+`rpgkit init` 은 소스 파일을 수정하지 않습니다. 코드 옆에 커맨드 정의, 런타임 스크립트, MCP 구성, 생성된 그래프 데이터를 추가합니다.
 
 ```text
 my-project/
-├── docs/                 # /rpgkit.feature_spec용 선택적 요구사항 문서
-├── .github/ or .claude/  # AI assistant 명령 정의 및 설정
-├── .vscode/              # 해당되는 경우 Copilot/VS Code MCP 구성
+├── docs/                 # /rpgkit.feature_spec 용 선택적 요구사항 문서
+├── .github/ or .claude/  # AI 어시스턴트 커맨드 정의 및 설정
+├── .vscode/              # 해당하는 경우 Copilot/VS Code MCP 구성
 └── .rpgkit/              # RPG-Kit 런타임
-    ├── scripts/          # 파이프라인 스크립트 및 지원 패키지
-    ├── data/             # rpg.json 및 dep_graph.json을 포함한 생성 아티팩트
+    ├── scripts/          # 파이프라인 스크립트와 지원 패키지
+    ├── data/             # 생성된 산출물 (rpg.json과 dep_graph.json 포함)
     ├── logs/             # 단계별 실행 로그
-    └── reports/          # 생성된 리뷰 및 진단 보고서
+    └── reports/          # 생성 시의 리뷰 및 진단 리포트
 ```
 
-전체 레이아웃 및 데이터 파일 참조는 [docs/project-structure.md](docs/project-structure.md)를 참조하세요.
+전체 레이아웃과 데이터 파일 참조는 [docs/project-structure.md](docs/project-structure.md) 를 참조하세요.
 
 ## 지원 플랫폼
 
-| 플랫폼                 | Claude Code | GitHub Copilot | Codex |
-| ---------------------- | ----------- | -------------- | ----- |
-| CLI 사용               | ✅          | ✅(MCP 없음)   | ⌛    |
-| VS Code 확장 사용      | ✅          | ✅             | ⌛    |
+| 플랫폼              | Claude Code | GitHub Copilot | Codex |
+| ------------------- | ----------- | -------------- | ----- |
+| CLI 사용            | ✅          | ✅ (No MCP)    | ⌛    |
+| VS Code 확장 사용   | ✅          | ✅             | ⌛    |
 
 | 스크립트 | Linux | Windows | Mac |
 | -------- | ----- | ------- | --- |
@@ -172,31 +213,31 @@ my-project/
 
 ## 문서
 
-- [Slash command 참조](docs/commands.md) — 모든 `/rpgkit.*` 명령, 입력, 출력, 예시.
-- [CLI 참조](docs/cli-reference.md) — `rpgkit init`, `rpgkit update`, `rpgkit check`, `rpgkit version` 및 모든 옵션.
-- [구성](docs/configuration.md) — AI assistant 설정, MCP 등록, hooks, 자동 승인, 문제 해결.
+- [슬래시 커맨드 레퍼런스](docs/commands.md) — 모든 `/rpgkit.*` 커맨드의 입력, 출력, 예시.
+- [CLI 레퍼런스](docs/cli-reference.md) — `rpgkit init`, `rpgkit update`, `rpgkit check`, `rpgkit version` 및 모든 옵션.
+- [구성](docs/configuration.md) — AI 어시스턴트 설정, MCP 등록, 훅, 자동 승인 및 트러블슈팅.
 - [프로젝트 구조](docs/project-structure.md) — RPG-Kit이 생성하는 파일과 디렉터리.
 
-## 예정 기능
+## 예정된 기능
 
-- **더 단순한 디코더 명령:** 현재 디코더 흐름을 더 적은 명령으로 병합합니다. 여기에는 엔드투엔드 리포지토리 생성을 위한 `/rpgkit.generate_repo`, 기능 생성과 RPG 계획을 위한 `/rpgkit.generate_feature` 및 `/rpgkit.plan`이 포함됩니다.
-- **다중 언어 지원:** Go, C++, Rust, JavaScript/TypeScript 등에 대한 지원을 추가합니다.
-- **더 많은 플랫폼 통합:** 다양한 시스템에서 여러 AI 코딩 에이전트를 위한 CLI 및 VS Code 확장 워크플로 전반에 RPG-Kit을 지원합니다.
+- **더 간단한 생성 커맨드:** 현재의 다단계 생성 흐름을 `/rpgkit.generate_repo`, `/rpgkit.generate_feature`, `/rpgkit.plan` 등 더 적은 커맨드로 통합합니다.
+- **다국어 지원:** Go, C++, Rust, JavaScript/TypeScript 등을 추가로 지원합니다.
+- **더 많은 플랫폼 통합:** 다양한 시스템에서 서로 다른 AI 코딩 에이전트의 CLI 및 VS Code 확장 워크플로에 걸쳐 RPG-Kit을 지원합니다.
 
-## 문제 해결
+## 트러블슈팅
 
-**AI assistant CLI를 찾을 수 없음:** `rpgkit check`를 실행하고, 선택한 assistant CLI를 설치 및 인증한 다음 `rpgkit init` 또는 `rpgkit update`를 다시 실행하세요.
+**AI 어시스턴트 CLI를 찾을 수 없음:** `rpgkit check` 를 실행하고, 선택한 어시스턴트 CLI를 설치 및 인증한 다음 `rpgkit init` 또는 `rpgkit update` 를 다시 실행하세요.
 
-**MCP 도구가 `rpg_unavailable`를 보고함:** `/rpgkit.encode`를 실행하여 `.rpgkit/data/rpg.json`을 생성하세요.
+**MCP 도구가 `rpg_unavailable` 을 보고함:** `/rpgkit.encode` 를 실행해 `.rpgkit/data/rpg.json` 을 생성하세요.
 
-**증분 업데이트 실패:** `.rpgkit/logs/update_rpg.log`를 확인한 다음 `/rpgkit.update_rpg`를 실행하세요.
+**증분 업데이트 실패:** `.rpgkit/logs/update_rpg.log` 를 확인한 다음 `/rpgkit.update_rpg` 를 실행하세요.
 
-**rate limit 또는 프라이빗 리포지토리 접근으로 인해 템플릿 다운로드 실패:** `--github-token $GITHUB_TOKEN`을 전달하거나 `GH_TOKEN` / `GITHUB_TOKEN`을 설정하세요.
+**속도 제한 또는 비공개 저장소 접근 권한으로 인해 템플릿 다운로드 실패:** `--github-token $GITHUB_TOKEN` 을 전달하거나 `GH_TOKEN` / `GITHUB_TOKEN` 을 설정하세요.
 
 ## 라이선스
 
-MIT License - 자세한 내용은 [LICENSE](LICENSE)를 참조하세요.
+MIT License — 자세한 내용은 [LICENSE](LICENSE) 참조.
 
 ## 감사의 말
 
-[GitHub Spec-Kit](https://github.com/github/spec-kit)을 기반으로 합니다.
+[GitHub Spec-Kit](https://github.com/github/spec-kit) 을 기반으로 합니다.

--- a/RPG-Kit/README.zh-CN.md
+++ b/RPG-Kit/README.zh-CN.md
@@ -8,35 +8,80 @@
   <a href="README.hi-IN.md">हिन्दी</a>
 </p>
 
-## 让 AI 编码智能体理解整个仓库
+## 让编码智能体先规划，再编辑
 
-AI 编码智能体很强大，但它们通常逐文件工作。随着项目增长，它们可能会丢失对需求、架构、依赖关系和既有设计决策的把握。
+编码智能体擅长局部编辑，但仓库级任务如果缺少稳定的规划结构往往会失败：需求漂移、架构决策丢失、多文件生成前后不一致、更新可能错过隐藏依赖。
 
-RPG-Kit 通过维护一个 **Repository Planning Graph (RPG)** 来帮助解决这个问题：这是一张结构化地图，连接需求、功能、文件、组件和依赖关系。
+RPG-Kit 为 Claude Code 和 GitHub Copilot 提供一个面向仓库级编码的**持久化 RPG 工作区**。这个工作区围绕一个 **Repository Planning Graph (RPG)** 构建，把需求、功能、架构、文件、代码实体和依赖关系连接在一起。
 
-当你希望 AI 智能体基于仓库级上下文工作，而不是依赖孤立的提示时，可以使用 RPG-Kit。
+借助 RPG-Kit，智能体可以通过图驱动的工作流来工作：
 
-### 为什么选择 RPG-Kit？
-
-| AI 编码智能体的常见问题 | RPG-Kit 如何帮助 |
-|---|---|
-| 智能体在几轮提示后忘记需求 | 需求会被编码进 RPG |
-| 智能体在不了解相关文件的情况下编辑单个文件 | 文件、组件和依赖关系会在图中连接起来 |
-| 生成的代码逐渐偏离原始计划 | 规划产物和代码会保持一致 |
-| 现有仓库很难让智能体理解 | 可以将代码库编码为 RPG |
-| 有针对性的编辑可能破坏隐藏依赖 | 编辑会基于图感知上下文进行 |
+- **构建（Build）**：把需求转换为 RPG 规划，然后生成一个多文件仓库。
+- **理解（Understand）**：把已有仓库映射为 RPG，然后搜索、浏览和解释它。
+- **更新（Update）**：定位受影响的 RPG 节点，规划编辑，并同步更新代码和图。
 
 ### 选择你的工作流
 
 | 目标 | 工作流 | 从这里开始 |
 |---|---|---|
-| 从需求创建新项目 | 正向工作流 | [`快速开始：新仓库`](#quick-start-new-repository) |
-| 理解或更新现有代码库 | 反向工作流 | [`快速开始：现有仓库`](#quick-start-existing-repository) |
-| 进行精确的仓库感知编辑 | 外科式编辑工作流 | [`快速开始：现有仓库`](#quick-start-existing-repository) |
+| 从需求构建一个新仓库 | Build 工作流（requirements → RPG → code） | [`快速开始：新仓库`](#快速开始新仓库) |
+| 理解一个已有仓库 | Understand 工作流（repository → RPG → search/explore） | [`快速开始：已有仓库`](#快速开始已有仓库) |
+| 更新一个已有仓库 | Update 工作流（change request → affected RPG nodes → edit plan → code/RPG update） | [`快速开始：已有仓库`](#快速开始已有仓库) |
 
-下面是为此仓库生成的部分图可视化结果。运行 `/rpgkit.encode` 并打开 `rpg.html`，即可探索完整的交互式图。
+### 详细流水线
 
-![RPG-Kit 仓库图可视化](../docs/rpgkit_visualized_graph.png)
+新用户可以跳过这一节，直接从下面的「快速开始」开始。
+
+<details>
+<summary>完整的命令级工作流图</summary>
+
+```text
+Forward Direction: Requirements → RPG → Code
+
+ Phase 1: Feature Specification       Phase 2: RPG Construction & Planning                             Phase 3
+┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
+│ feature  │ │ feature  │ │ feature  │ │  build   │ │  build   │ │ design   │ │ design   │ │  plan    │ │          │
+│  _spec   ├─▶  _build  ├─▶_refactor ├─▶ skeleton ├─▶  data    ├─▶  base    ├─▶interfaces├─▶  tasks  ├─▶ code_gen │
+│          │ │          │ │          │ │          │ │  flow    │ │ classes  │ │          │ │          │ │   (TDD)  │
+└──────────┘ └──────────┘ └────┬─────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘ └────┬─────┘
+ feature_     feature_        │        skeleton     data_flow    base_        interfaces   tasks        source
+ spec/        build           │        .json        .json        classes      .json        .json        code
+ feature_     .json           │        skeleton_    data_flow    .json
+ spec.json                    │        summary.txt  _viz.html
+                              │
+                       ┌──────▼──────┐
+                       │ feature_edit│ optional pre-planning edits to feature_tree.json
+                       └─────────────┘
+                                        ╰───── rpg.json (created → progressively enriched) ─────╯
+                                                                            │
+                                                                            ▼
+                                                                     ┌──────────┐
+Surgical edit workflow: Requirements -> RPG update -> Code Update    │ rpg_edit │ optional synchronized RPG + code + dep_graph edits
+                                                                     └──▲────▲──┘
+                                                                        │    │
+Reverse Direction: Code → RPG                                           │    │
+                                                                        │    │
+┌──────────────────┐         ┌──────────┐       ┌──────────┐            │    │
+│ Existing Codebase│────────▶│  encode  │──────▶│update_rpg│────────────┘    │
+│                  │         │  (full)  │       │ (manual  │                 │
+└──────────────────┘         └────┬─────┘       │ fallback)│                 │
+                              rpg.json          └──────────┘                 │
+                              dep_graph.json     rpg.json / dep_graph.json   │
+                                  │                                          │
+                                  └──────────────────────────────────────────┘
+                                                  ▲
+                                                  │ post-commit hook normally runs incremental updates
+
+MCP Server: search_rpg / explore_rpg / get_node_detail / list_rpg_tree
+```
+
+</details>
+
+### RPG-Kit 实际效果
+
+下图是为本仓库生成的图可视化的一部分。运行 `/rpgkit.encode`，然后打开 `.rpgkit/data/rpg.html` 浏览完整的交互式图。
+
+![RPG-Kit repository graph visualization](../docs/rpgkit_visualized_graph.png)
 
 ## 安装
 
@@ -45,12 +90,12 @@ RPG-Kit 通过维护一个 **Repository Planning Graph (RPG)** 来帮助解决�
 - Python 3.12+
 - [uv](https://docs.astral.sh/uv/)
 - Git
-- 已安装并完成身份验证的 AI 编码智能体 CLI：[GitHub Copilot](https://docs.github.com/en/copilot) 或 [Claude Code](https://docs.anthropic.com/en/docs/claude-code/setup)
+- 一个已安装并完成身份验证的 AI 编码智能体 CLI：[GitHub Copilot](https://docs.github.com/en/copilot) 或 [Claude Code](https://docs.anthropic.com/en/docs/claude-code/setup)
 
 ### 安装 RPG-Kit
 
 ```bash
-# 持久安装（推荐）
+# 持久化安装（推荐）
 uv tool install rpgkit-cli --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-Kit"
 rpgkit check
 
@@ -58,16 +103,14 @@ rpgkit check
 uvx --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-Kit" rpgkit init <project-name>
 ```
 
-<a id="quick-start-new-repository"></a>
-
 ## 快速开始：新仓库
 
-当你想让 RPG-Kit 将需求转换为新代码库时，使用此路径。
+当你希望 RPG-Kit 把需求转换为新代码库时，使用此路径。
 
 > [!WARNING]
-> 对于生成代码量比较大的项目，`/rpgkit.design_interfaces` 和 `/rpgkit.code_gen` 的运行时间会比较长。一个典型的例子：特征数为100，运行时间大约30分钟。
+> 对于生成代码量较大的项目，`/rpgkit.design_interfaces` 和 `/rpgkit.code_gen` 可能运行较长时间。典型例子：100 个 feature 大约需要 30 分钟。
 
-1. 初始化新项目：
+1. 初始化一个新项目：
 
    ```bash
    rpgkit init my-project
@@ -82,9 +125,9 @@ uvx --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-K
    rpgkit init my-project --github-token $GITHUB_TOKEN
    ```
 
-2. **[可选]** 将你的需求文档放入 `my-project/docs/`。
+2. **[可选]** 把你的需求文档放在 `my-project/docs/`。
 
-3. 在项目目录中启动你的 AI 编码智能体。
+3. 在项目目录里启动你的 AI 编码智能体。
 
 4. 运行正向流水线：
 
@@ -102,18 +145,16 @@ uvx --from "git+https://github.com/microsoft/RPG-ZeroRepo.git#subdirectory=RPG-K
    [Optional] /rpgkit.rpg_edit <edit instructions>
    ```
 
-RPG-Kit 会逐步创建 `.rpgkit/data/rpg.json`，并使用它来保持需求、规划产物、生成的代码和依赖信息一致。
+RPG-Kit 会渐进式地创建 `.rpgkit/data/rpg.json`，并用它把需求、规划产物、生成的代码和依赖信息保持对齐。
 
-<a id="quick-start-existing-repository"></a>
+## 快速开始：已有仓库
 
-## 快速开始：现有仓库
-
-当你已经有一个代码仓库，并希望 AI 智能体借助 RPG 上下文理解或编辑它时，使用此路径。
+当你已经有一个仓库，希望 AI 智能体在 RPG 上下文中理解或编辑它时，使用此路径。
 
 > [!WARNING]
-> 对于比较大的项目，`rpgkit init . --encode` 和 `/rpgkit.encode` 的运行时间可能会比较长。一个典型的例子：源代码文件数为200，运行时间100分钟。
+> 对于较大的项目，`rpgkit init . --encode` 和 `/rpgkit.encode` 可能运行较长时间。典型例子：200 个源文件大约需要 100 分钟。
 
-1. 在仓库根目录初始化 RPG-Kit，并构建初始图：
+1. 在仓库根目录初始化 RPG-Kit 并构建初始图：
 
    ```bash
    mkdir my-project
@@ -128,42 +169,42 @@ RPG-Kit 会逐步创建 `.rpgkit/data/rpg.json`，并使用它来保持需求、
    rpgkit init . --force --encode
    ```
 
-2. 在仓库中启动你的 AI 编码智能体。
+2. 在仓库里启动你的 AI 编码智能体。
 
-3. 通过 MCP 工具和斜杠命令使用生成的 RPG：
+3. 通过 MCP 工具和 slash 命令使用生成的 RPG：
 
    ```text
    /rpgkit.encode                                  # 需要时重建完整 RPG
-   /rpgkit.update_rpg                              # 手动增量更新兜底
-   /rpgkit.rpg_edit <edit instructions>            # 图感知代码编辑
+   /rpgkit.update_rpg                              # 手动增量更新（fallback）
+   /rpgkit.rpg_edit <edit instructions>            # 图感知的代码编辑
    ```
 
-4. 提交后，RPG-Kit hooks 会保持 `.rpgkit/data/rpg.json`、`.rpgkit/data/dep_graph.json` 和 `.rpgkit/data/rpg.html` 与代码改动一致。如果 hook 失败或被跳过，请运行 `/rpgkit.update_rpg`。
+4. 提交后，RPG-Kit hook 会把 `.rpgkit/data/rpg.json`、`.rpgkit/data/dep_graph.json` 和 `.rpgkit/data/rpg.html` 与代码变更保持对齐。如果 hook 失败或被跳过，运行 `/rpgkit.update_rpg`。
 
-## 新增内容
+## `rpgkit init` 之后会发生什么
 
-运行 `rpgkit init` 后，workspace root 仍然是你的项目仓库根目录。RPG-Kit 会将命令定义、运行时脚本、MCP 配置和生成的图数据与代码一起添加到项目中。
+`rpgkit init` 不会修改你的源文件。它会在你的代码旁边添加命令定义、运行时脚本、MCP 配置和生成的图数据。
 
 ```text
 my-project/
 ├── docs/                 # /rpgkit.feature_spec 的可选需求文档
-├── .github/ or .claude/  # AI assistant 命令定义和设置
+├── .github/ or .claude/  # AI 助手的命令定义和设置
 ├── .vscode/              # 适用时的 Copilot/VS Code MCP 配置
 └── .rpgkit/              # RPG-Kit 运行时
     ├── scripts/          # 流水线脚本和支持包
-    ├── data/             # 生成产物，包括 rpg.json 和 dep_graph.json
-    ├── logs/             # 每个阶段的执行日志
-    └── reports/          # 生成的评审和诊断报告
+    ├── data/             # 生成的产物，包括 rpg.json 和 dep_graph.json
+    ├── logs/             # 各阶段执行日志
+    └── reports/          # 生成时的审查与诊断报告
 ```
 
-完整目录布局和数据文件参考见 [docs/project-structure.md](docs/project-structure.md)。
+完整的目录布局和数据文件参考见 [docs/project-structure.md](docs/project-structure.md)。
 
 ## 支持的平台
 
-| 平台                    | Claude Code | GitHub Copilot | Codex |
-| ----------------------- | ----------- | -------------- | ----- |
-| CLI 使用                | ✅          | ✅(无 MCP)     | ⌛    |
-| VS Code 扩展使用        | ✅          | ✅             | ⌛    |
+| 平台                | Claude Code | GitHub Copilot | Codex |
+| ------------------- | ----------- | -------------- | ----- |
+| CLI 使用            | ✅          | ✅ (No MCP)    | ⌛    |
+| VS Code 扩展使用    | ✅          | ✅             | ⌛    |
 
 | 脚本 | Linux | Windows | Mac |
 | ---- | ----- | ------- | --- |
@@ -172,30 +213,30 @@ my-project/
 
 ## 文档
 
-- [斜杠命令参考](docs/commands.md) — 每个 `/rpgkit.*` 命令、输入、输出和示例。
-- [CLI 参考](docs/cli-reference.md) — `rpgkit init`、`rpgkit update`、`rpgkit check`、`rpgkit version` 以及所有选项。
-- [配置](docs/configuration.md) — AI assistant 设置、MCP 注册、hooks、自动批准和故障排除。
-- [项目结构](docs/project-structure.md) — RPG-Kit 创建的文件和目录。
+- [Slash 命令参考](docs/commands.md) —— 每一个 `/rpgkit.*` 命令的输入、输出和示例。
+- [CLI 参考](docs/cli-reference.md) —— `rpgkit init`、`rpgkit update`、`rpgkit check`、`rpgkit version` 以及所有选项。
+- [配置](docs/configuration.md) —— AI 助手设置、MCP 注册、hook、自动审批和故障排查。
+- [项目结构](docs/project-structure.md) —— RPG-Kit 创建的文件和目录。
 
 ## 即将推出的功能
 
-- **更简单的解码器命令：** 将当前解码器流程合并为更少的命令，包括用于端到端仓库生成的 `/rpgkit.generate_repo`，以及用于功能生成和 RPG 规划的 `/rpgkit.generate_feature` 加 `/rpgkit.plan`。
-- **多语言支持：** 增加对 Go、C++、Rust、JavaScript/TypeScript 等语言的支持。
-- **更多平台集成：** 支持 RPG-Kit 在不同系统上与不同 AI 编码智能体的 CLI 和 VS Code 扩展工作流配合使用。
+- **更简化的生成命令**：把当前多步骤的生成流程合并为更少的命令，例如 `/rpgkit.generate_repo`、`/rpgkit.generate_feature` 和 `/rpgkit.plan`。
+- **多语言支持**：增加对 Go、C++、Rust、JavaScript/TypeScript 等的支持。
+- **更多平台集成**：在不同系统上跨 CLI 和 VS Code 扩展工作流支持不同的 AI 编码智能体。
 
-## 故障排除
+## 故障排查
 
-**找不到 AI assistant CLI：** 运行 `rpgkit check`，安装并认证所选 assistant CLI，然后重新运行 `rpgkit init` 或 `rpgkit update`。
+**找不到 AI 助手 CLI**：运行 `rpgkit check`，安装并完成所选助手 CLI 的身份验证，然后重新运行 `rpgkit init` 或 `rpgkit update`。
 
-**MCP 工具报告 `rpg_unavailable`：** 运行 `/rpgkit.encode` 来创建 `.rpgkit/data/rpg.json`。
+**MCP 工具报告 `rpg_unavailable`**：运行 `/rpgkit.encode` 来创建 `.rpgkit/data/rpg.json`。
 
-**增量更新失败：** 检查 `.rpgkit/logs/update_rpg.log`，然后运行 `/rpgkit.update_rpg`。
+**增量更新失败**：检查 `.rpgkit/logs/update_rpg.log`，然后运行 `/rpgkit.update_rpg`。
 
-**由于速率限制或私有仓库访问导致模板下载失败：** 传入 `--github-token $GITHUB_TOKEN`，或设置 `GH_TOKEN` / `GITHUB_TOKEN`。
+**因为速率限制或私有仓库访问导致模板下载失败**：传递 `--github-token $GITHUB_TOKEN`，或设置 `GH_TOKEN` / `GITHUB_TOKEN`。
 
 ## 许可证
 
-MIT License - 详见 [LICENSE](LICENSE)。
+MIT License —— 详情见 [LICENSE](LICENSE)。
 
 ## 致谢
 


### PR DESCRIPTION
## Summary

After PR #53 merged the main RPG-Kit branch into `main`, an additional commit on `dev/rpgkit_checkin` synced the four non-English RPG-Kit READMEs to match the latest English version. That commit is not yet on `main`.

This tiny follow-up PR pulls just that one commit (`b318dcb`) into `main`.

## What changed

Only 4 files in `RPG-Kit/`:

- `README.zh-CN.md`
- `README.ja-JP.md`
- `README.ko-KR.md`
- `README.hi-IN.md`

Each was rewritten to mirror the current English `README.md`:

- New heading "Make coding agents plan before they edit" (was "Make AI coding agents understand the whole repository")
- Updated opening paragraphs with the persistent RPG workspace framing
- New Build / Understand / Update three-bullet workflow list
- "Choose your workflow" table relabelled Forward / Reverse / Surgical → Build / Understand / Update
- Detailed pipeline folded into a `<details>` block
- New "RPG-Kit in action" subheading
- `.rpgkit/data/rpg.html` path in caption
- "After rpgkit init" sentence rewritten for clarity
- "Simpler decoder commands" → "Simpler generation commands"
- "✅(No MCP)" → "✅ (No MCP)"

All code blocks, slash commands, file paths, URLs, image references, and the large ASCII pipeline diagram are byte-identical with the English version. Only prose and `#` comments are translated.

## Test plan

- [ ] Spot-check rendering of each translated README on GitHub
- [ ] Spot-check anchor links in the translated Quick Start sections
- [ ] Native-speaker review (optional but recommended) — confidence high for zh-CN / ja-JP, medium for ko-KR / hi-IN

🤖 Generated with [Claude Code](https://claude.com/claude-code)